### PR TITLE
Removed lowerCasing headers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,7 @@ HTTPSnippet.prototype.prepare = function (request) {
   if (request.headers && request.headers.length) {
     // loweCase header keys
     request.headersObj = request.headers.reduceRight(function (headers, header) {
-      headers[header.name.toLowerCase()] = header.value
+      headers[header.name] = header.value
       return headers
     }, {})
   }


### PR DESCRIPTION
Removed the lowerCasing of headers. This might result in some duplicate headers, but they are specified by the source anyways, we leave that responsibility to the user.
Mostly for aesthetics.